### PR TITLE
Add Sessions & Add New Email

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,9 @@ def with_auth_context(f):
 @with_auth_context
 def index() -> str:
     if g.auth_context:
-        return redirect(url_for("account"))
+        email = g.auth_context.get("user").emails[0].email
+        resp = make_response(render_template("loggedIn.html", email=email))
+        return resp
     
     resp = make_response(render_template("loginOrSignUp.html"))
     resp.delete_cookie("stytch-session")
@@ -84,7 +86,6 @@ def login_or_create_user() -> str:
             signup_magic_link_url=MAGIC_LINK_URL,
         )
     except:
-        print(resp)
         return "something went wrong sending magic link"
  
     return render_template("emailSent.html", type="login")
@@ -99,7 +100,6 @@ def authenticate():
     try:
         resp = stytch_client.magic_links.authenticate(token=request.args["token"], session_duration_minutes=5)
     except:
-        print(resp)
         return "something went wrong authenticating token"
     
     stytch_session = resp.session_token
@@ -118,7 +118,6 @@ def authenticate():
 @auth_required
 def account():
     emails = []
-    print(g.auth_context)
     user = g.auth_context.get("user")
     for email in user.emails:
         emails.append(email.email)
@@ -141,7 +140,6 @@ def add_email():
             signup_magic_link_url=MAGIC_LINK_URL,
         )
     except:
-        print(resp)
         return "something went wrong sending magic link"
 
     return render_template("emailSent.html", type="authentication")

--- a/templates/account.html
+++ b/templates/account.html
@@ -23,12 +23,24 @@
     <div class="content">
         <div class="card">
             <div class="cardContent">
-                <h1>You've got mail!</h1>
-                <p>Check your inbox (including the promotions folder) <br/>for the {{ type }} link.</p>
-                <p>Didn't find it? <a><b>Send it again.</b></a></p>
+                <h1>Account Details</h1>
+                <p><b>UserID:</b> {{ user_id }}</p>
+                <p><b>Emails:</b> {{ emails }} </p>
+                <form action="{{ url_for('add_email')}}" method="POST">
+                    <div class="actions">
+                        <input type="text" name="email" placeholder="Add another email to your account?" />
+                        <input class="arrow" type="image" src="{{ url_for('static', filename= 'images/arrow.png') }}">
+                    </div>
+                </form>
+                <p></p>
+                <form action="{{ url_for('logout')}}" method="GET">
+                    <div class="actions">
+                        <a><b>Logout</b></a>
+                        <input class="arrow" type="image" src="{{ url_for('static', filename= 'images/arrow.png') }}">
+                    </div>
+                </form>
             </div>
         </div>
     </div>
-</div>
 </body>
 </html>

--- a/templates/loggedIn.html
+++ b/templates/loggedIn.html
@@ -23,11 +23,11 @@
     <div class="content">
         <div class="card">
             <div class="cardContent">
-                <h1>Welcome back!</h1>
+                <h1>Hello {{ email }}!</h1>
                 <p>Your socks just can't wait to be shipped!</p>
-                <form action="{{ url_for('logout')}}" method="GET">
+                <form action="{{ url_for('account')}}" method="GET">
                     <div class="actions">
-                        <a><b>Logout</b></a>
+                        <a><b>View Account</b></a>
                         <input class="arrow" type="image" src="{{ url_for('static', filename= 'images/arrow.png') }}">
                     </div>
                 </form>

--- a/templates/loggedOut.html
+++ b/templates/loggedOut.html
@@ -25,6 +25,12 @@
             <div class="cardContent">
                 <h1>Enjoy your socks!</h1>
                 <p>We'll see you next time.</p>
+                <form action="{{ url_for('index')}}" method="GET">
+                    <div class="actions">
+                        <a><b>Log back in? </b></a>
+                        <input class="arrow" type="image" src="{{ url_for('static', filename= 'images/arrow.png') }}">
+                    </div>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Overview
This PR introduces the following new functionality:
1. Adds Stytch Sessions to maintain authenticated state
2. Add concept of an "Account page" that is only accessible in an authenticated state, and to show some basic profile info
4. Allow logged in users to add another email to their account through the `/send` flow

I also updated the error handling from the `if resp.status_code != 200` to a try/except pattern, since it seems like errors from within the Stytch Python SDK throw exceptions. As a side note: is there a package for these exceptions that could allow for more targeted handling?

### Callouts
My design + HTML skills are...lacking, and so the account page layout is sort of ugly. Very open to suggestions to make this less janky looking
![Screenshot 2023-01-28 at 3 34 02 PM](https://user-images.githubusercontent.com/103593791/215570074-83fc291a-8418-41c1-ba8e-4d8931c2e9a6.png)

### Before Merging
I only updated the synchronous version -- will also add to the async version if we want to move forward with these changes so we don't break that
