### PR TITLE
Bumping stytch sdk version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .vscode/
 .venv
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask[async]>=2.2.2
 python-dotenv>=0.20.0
-stytch>=6.0.1
+stytch>=7.6.0


### PR DESCRIPTION
It was already resolving to 7.6.0 but making it official.

Also, added venv to .gitignore since the README has the dev create it at venv, not .venv