### PR TITLE
[WEB-3894] Update venv command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Close this repository and navigate to the folder with the source code on your ma
 
 We suggest creating a [virtualenv](https://docs.python.org/3/library/venv.html) and activating it to avoid installing dependencies globally
 
-- `virtualenv -p python3 venv`
+- `python3 -m venv venv`
 - `source venv/bin/activate`
 
 ##### 3. Install dependencies:


### PR DESCRIPTION
Updates the venv installation command so that it works without an extra installation.